### PR TITLE
feat: optional flag to treat bip32 paths as relative

### DIFF
--- a/src/lib/converter/index.d.ts
+++ b/src/lib/converter/index.d.ts
@@ -27,7 +27,7 @@ declare const inputs: {
     porCommitment: typeof porCommitment;
     witnessUtxo: typeof witnessUtxo;
     bip32Derivation: {
-        decode: (keyVal: import("../interfaces").KeyValue) => import("../interfaces").Bip32Derivation;
+        decode: (keyVal: import("../interfaces").KeyValue, bip32PathsAbsolute?: boolean | undefined) => import("../interfaces").Bip32Derivation;
         encode: (data: import("../interfaces").Bip32Derivation) => import("../interfaces").KeyValue;
         check: (data: any) => data is import("../interfaces").Bip32Derivation;
         expected: string;
@@ -52,7 +52,7 @@ declare const inputs: {
     tapScriptSig: typeof tapScriptSig;
     tapLeafScript: typeof tapLeafScript;
     tapBip32Derivation: {
-        decode: (keyVal: import("../interfaces").KeyValue) => import("../interfaces").TapBip32Derivation;
+        decode: (keyVal: import("../interfaces").KeyValue, bip32PathsAbsolute: boolean) => import("../interfaces").TapBip32Derivation;
         encode: (data: import("../interfaces").TapBip32Derivation) => import("../interfaces").KeyValue;
         check: (data: any) => data is import("../interfaces").TapBip32Derivation;
         expected: string;
@@ -69,7 +69,7 @@ declare const inputs: {
 };
 declare const outputs: {
     bip32Derivation: {
-        decode: (keyVal: import("../interfaces").KeyValue) => import("../interfaces").Bip32Derivation;
+        decode: (keyVal: import("../interfaces").KeyValue, bip32PathsAbsolute?: boolean | undefined) => import("../interfaces").Bip32Derivation;
         encode: (data: import("../interfaces").Bip32Derivation) => import("../interfaces").KeyValue;
         check: (data: any) => data is import("../interfaces").Bip32Derivation;
         expected: string;
@@ -91,7 +91,7 @@ declare const outputs: {
     };
     checkPubkey: (keyVal: import("../interfaces").KeyValue) => Buffer | undefined;
     tapBip32Derivation: {
-        decode: (keyVal: import("../interfaces").KeyValue) => import("../interfaces").TapBip32Derivation;
+        decode: (keyVal: import("../interfaces").KeyValue, bip32PathsAbsolute: boolean) => import("../interfaces").TapBip32Derivation;
         encode: (data: import("../interfaces").TapBip32Derivation) => import("../interfaces").KeyValue;
         check: (data: any) => data is import("../interfaces").TapBip32Derivation;
         expected: string;

--- a/src/lib/converter/shared/bip32Derivation.d.ts
+++ b/src/lib/converter/shared/bip32Derivation.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { Bip32Derivation, KeyValue } from '../../interfaces';
 export declare function makeConverter(TYPE_BYTE: number, isValidPubkey?: (pubkey: Buffer) => boolean): {
-    decode: (keyVal: KeyValue) => Bip32Derivation;
+    decode: (keyVal: KeyValue, bip32PathsAbsolute?: boolean) => Bip32Derivation;
     encode: (data: Bip32Derivation) => KeyValue;
     check: (data: any) => data is Bip32Derivation;
     expected: string;

--- a/src/lib/converter/shared/tapBip32Derivation.d.ts
+++ b/src/lib/converter/shared/tapBip32Derivation.d.ts
@@ -1,6 +1,6 @@
 import { KeyValue, TapBip32Derivation } from '../../interfaces';
 export declare function makeConverter(TYPE_BYTE: number): {
-    decode: (keyVal: KeyValue) => TapBip32Derivation;
+    decode: (keyVal: KeyValue, bip32PathsAbsolute: boolean) => TapBip32Derivation;
     encode: (data: TapBip32Derivation) => KeyValue;
     check: (data: any) => data is TapBip32Derivation;
     expected: string;

--- a/src/lib/converter/shared/tapBip32Derivation.js
+++ b/src/lib/converter/shared/tapBip32Derivation.js
@@ -5,13 +5,16 @@ const bip32Derivation = require('./bip32Derivation');
 const isValidBIP340Key = pubkey => pubkey.length === 32;
 function makeConverter(TYPE_BYTE) {
   const parent = bip32Derivation.makeConverter(TYPE_BYTE, isValidBIP340Key);
-  function decode(keyVal) {
+  function decode(keyVal, bip32PathsAbsolute = true) {
     const nHashes = varuint.decode(keyVal.value);
     const nHashesLen = varuint.encodingLength(nHashes);
-    const base = parent.decode({
-      key: keyVal.key,
-      value: keyVal.value.slice(nHashesLen + nHashes * 32),
-    });
+    const base = parent.decode(
+      {
+        key: keyVal.key,
+        value: keyVal.value.slice(nHashesLen + nHashes * 32),
+      },
+      bip32PathsAbsolute,
+    );
     const leafHashes = new Array(nHashes);
     for (let i = 0, _offset = nHashesLen; i < nHashes; i++, _offset += 32) {
       leafHashes[i] = keyVal.value.slice(_offset, _offset + 32);

--- a/src/lib/parser/fromBuffer.d.ts
+++ b/src/lib/parser/fromBuffer.d.ts
@@ -1,12 +1,16 @@
 /// <reference types="node" />
 import { KeyValue, Transaction, TransactionFromBuffer } from '../interfaces';
 import { PsbtAttributes } from './index';
-export declare function psbtFromBuffer(buffer: Buffer, txGetter: TransactionFromBuffer): PsbtAttributes;
+export declare function psbtFromBuffer(buffer: Buffer, txGetter: TransactionFromBuffer, { bip32PathsAbsolute }?: {
+    bip32PathsAbsolute?: boolean | undefined;
+}): PsbtAttributes;
 interface PsbtFromKeyValsArg {
     globalMapKeyVals: KeyValue[];
     inputKeyVals: KeyValue[][];
     outputKeyVals: KeyValue[][];
 }
 export declare function checkKeyBuffer(type: string, keyBuf: Buffer, keyNum: number): void;
-export declare function psbtFromKeyVals(unsignedTx: Transaction, { globalMapKeyVals, inputKeyVals, outputKeyVals }: PsbtFromKeyValsArg): PsbtAttributes;
+export declare function psbtFromKeyVals(unsignedTx: Transaction, { globalMapKeyVals, inputKeyVals, outputKeyVals }: PsbtFromKeyValsArg, { bip32PathsAbsolute }?: {
+    bip32PathsAbsolute?: boolean | undefined;
+}): PsbtAttributes;
 export {};

--- a/src/lib/parser/fromBuffer.js
+++ b/src/lib/parser/fromBuffer.js
@@ -4,7 +4,7 @@ const convert = require('../converter');
 const tools_1 = require('../converter/tools');
 const varuint = require('../converter/varint');
 const typeFields_1 = require('../typeFields');
-function psbtFromBuffer(buffer, txGetter) {
+function psbtFromBuffer(buffer, txGetter, { bip32PathsAbsolute = true } = {}) {
   let offset = 0;
   function varSlice() {
     const keyLen = varuint.decode(buffer, offset);
@@ -114,11 +114,15 @@ function psbtFromBuffer(buffer, txGetter) {
     }
     outputKeyVals.push(output);
   }
-  return psbtFromKeyVals(unsignedTx, {
-    globalMapKeyVals,
-    inputKeyVals,
-    outputKeyVals,
-  });
+  return psbtFromKeyVals(
+    unsignedTx,
+    {
+      globalMapKeyVals,
+      inputKeyVals,
+      outputKeyVals,
+    },
+    { bip32PathsAbsolute },
+  );
 }
 exports.psbtFromBuffer = psbtFromBuffer;
 function checkKeyBuffer(type, keyBuf, keyNum) {
@@ -132,6 +136,7 @@ exports.checkKeyBuffer = checkKeyBuffer;
 function psbtFromKeyVals(
   unsignedTx,
   { globalMapKeyVals, inputKeyVals, outputKeyVals },
+  { bip32PathsAbsolute = true } = {},
 ) {
   // That was easy :-)
   const globalMap = {
@@ -244,7 +249,7 @@ function psbtFromKeyVals(
             input.bip32Derivation = [];
           }
           input.bip32Derivation.push(
-            convert.inputs.bip32Derivation.decode(keyVal),
+            convert.inputs.bip32Derivation.decode(keyVal, bip32PathsAbsolute),
           );
           break;
         case typeFields_1.InputTypes.FINAL_SCRIPTSIG:
@@ -298,7 +303,10 @@ function psbtFromKeyVals(
             input.tapBip32Derivation = [];
           }
           input.tapBip32Derivation.push(
-            convert.inputs.tapBip32Derivation.decode(keyVal),
+            convert.inputs.tapBip32Derivation.decode(
+              keyVal,
+              bip32PathsAbsolute,
+            ),
           );
           break;
         case typeFields_1.InputTypes.TAP_INTERNAL_KEY:
@@ -357,7 +365,7 @@ function psbtFromKeyVals(
             output.bip32Derivation = [];
           }
           output.bip32Derivation.push(
-            convert.outputs.bip32Derivation.decode(keyVal),
+            convert.outputs.bip32Derivation.decode(keyVal, bip32PathsAbsolute),
           );
           break;
         case typeFields_1.OutputTypes.TAP_INTERNAL_KEY:
@@ -381,7 +389,10 @@ function psbtFromKeyVals(
             output.tapBip32Derivation = [];
           }
           output.tapBip32Derivation.push(
-            convert.outputs.tapBip32Derivation.decode(keyVal),
+            convert.outputs.tapBip32Derivation.decode(
+              keyVal,
+              bip32PathsAbsolute,
+            ),
           );
           break;
         default:

--- a/src/lib/psbt.d.ts
+++ b/src/lib/psbt.d.ts
@@ -1,9 +1,15 @@
 /// <reference types="node" />
 import { KeyValue, PsbtGlobal, PsbtGlobalUpdate, PsbtInput, PsbtInputExtended, PsbtInputUpdate, PsbtOutput, PsbtOutputExtended, PsbtOutputUpdate, Transaction, TransactionFromBuffer } from './interfaces';
 export declare class Psbt {
-    static fromBase64<T extends typeof Psbt>(this: T, data: string, txFromBuffer: TransactionFromBuffer): InstanceType<T>;
-    static fromHex<T extends typeof Psbt>(this: T, data: string, txFromBuffer: TransactionFromBuffer): InstanceType<T>;
-    static fromBuffer<T extends typeof Psbt>(this: T, buffer: Buffer, txFromBuffer: TransactionFromBuffer): InstanceType<T>;
+    static fromBase64<T extends typeof Psbt>(this: T, data: string, txFromBuffer: TransactionFromBuffer, { bip32PathsAbsolute }?: {
+        bip32PathsAbsolute?: boolean | undefined;
+    }): InstanceType<T>;
+    static fromHex<T extends typeof Psbt>(this: T, data: string, txFromBuffer: TransactionFromBuffer, { bip32PathsAbsolute }?: {
+        bip32PathsAbsolute?: boolean | undefined;
+    }): InstanceType<T>;
+    static fromBuffer<T extends typeof Psbt>(this: T, buffer: Buffer, txFromBuffer: TransactionFromBuffer, { bip32PathsAbsolute }?: {
+        bip32PathsAbsolute?: boolean | undefined;
+    }): InstanceType<T>;
     readonly inputs: PsbtInput[];
     readonly outputs: PsbtOutput[];
     readonly globalMap: PsbtGlobal;

--- a/src/lib/psbt.js
+++ b/src/lib/psbt.js
@@ -12,16 +12,18 @@ class Psbt {
       unsignedTx: tx,
     };
   }
-  static fromBase64(data, txFromBuffer) {
+  static fromBase64(data, txFromBuffer, { bip32PathsAbsolute = true } = {}) {
     const buffer = Buffer.from(data, 'base64');
-    return this.fromBuffer(buffer, txFromBuffer);
+    return this.fromBuffer(buffer, txFromBuffer, { bip32PathsAbsolute });
   }
-  static fromHex(data, txFromBuffer) {
+  static fromHex(data, txFromBuffer, { bip32PathsAbsolute = true } = {}) {
     const buffer = Buffer.from(data, 'hex');
-    return this.fromBuffer(buffer, txFromBuffer);
+    return this.fromBuffer(buffer, txFromBuffer, { bip32PathsAbsolute });
   }
-  static fromBuffer(buffer, txFromBuffer) {
-    const results = parser_1.psbtFromBuffer(buffer, txFromBuffer);
+  static fromBuffer(buffer, txFromBuffer, { bip32PathsAbsolute = true } = {}) {
+    const results = parser_1.psbtFromBuffer(buffer, txFromBuffer, {
+      bip32PathsAbsolute,
+    });
     const psbt = new this(results.globalMap.unsignedTx);
     Object.assign(psbt, results);
     return psbt;

--- a/src/tests/fixtures/update.js
+++ b/src/tests/fixtures/update.js
@@ -65,7 +65,7 @@ exports.fixtures = [
             pubkey: b(
               '023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e73',
             ),
-            path: "m/0'/0'/3'",
+            path: "0'/0'/3'",
           },
           {
             masterFingerprint: b('d90c6a4f'),
@@ -96,7 +96,7 @@ exports.fixtures = [
             pubkey: b(
               '027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b50051096',
             ),
-            path: "m/0'/0'/5'",
+            path: "0'/0'/5'",
           },
         ],
       },

--- a/src/tests/fromBIP/valid.js
+++ b/src/tests/fromBIP/valid.js
@@ -4,16 +4,40 @@ const tape = require('tape');
 const psbt_1 = require('../../lib/psbt');
 const valid_1 = require('../fixtures/valid');
 const txTools_1 = require('../utils/txTools');
-for (const f of valid_1.fixtures) {
-  tape(`Test: Should not throw`, t => {
-    let psbt;
-    t.doesNotThrow(() => {
-      psbt = psbt_1.Psbt.fromBase64(f, txTools_1.transactionFromBuffer);
-    }, 'fromBase64');
-    t.doesNotThrow(() => {
-      const out = psbt.toBase64();
-      t.equal(out, f);
-    }, 'toBase64');
-    t.end();
-  });
+function getPaths(m) {
+  return m
+    .map(ele =>
+      [...(ele.bip32Derivation || []), ...(ele.tapBip32Derivation || [])].map(
+        ({ path }) => path,
+      ),
+    )
+    .reduce((a, b) => [...a, ...b], []);
 }
+[true, false].forEach(bip32PathsAbsolute => {
+  for (const f of valid_1.fixtures) {
+    tape(
+      `Test: Should not throw (bip32PathsAbsolute:${bip32PathsAbsolute})`,
+      t => {
+        let psbt;
+        t.doesNotThrow(() => {
+          psbt = psbt_1.Psbt.fromBase64(f, txTools_1.transactionFromBuffer, {
+            bip32PathsAbsolute,
+          });
+          const paths = [...getPaths(psbt.inputs), ...getPaths(psbt.outputs)];
+          paths.forEach(path => {
+            if (bip32PathsAbsolute) {
+              t.equal(path[0], 'm');
+            } else if (path.length > 0) {
+              t.assert(path[0].match(/\d/));
+            }
+          });
+        }, 'fromBase64');
+        t.doesNotThrow(() => {
+          const out = psbt.toBase64();
+          t.equal(out, f);
+        }, 'toBase64');
+        t.end();
+      },
+    );
+  }
+});

--- a/src/tests/fromBuffer.js
+++ b/src/tests/fromBuffer.js
@@ -29,6 +29,17 @@ for (const f of fromBuffer_1.fixtures) {
     t.throws(() => {
       psbt_1.Psbt.fromHex(f.hex, fromBuf);
     }, new RegExp(f.exception));
+    t.throws(() => {
+      psbt_1.Psbt.fromBuffer(Buffer.from(f.hex, 'hex'), fromBuf);
+    }, new RegExp(f.exception));
+    t.throws(() => {
+      psbt_1.Psbt.fromHex(f.hex, fromBuf, { bip32PathsAbsolute: false });
+    }, new RegExp(f.exception));
+    t.throws(() => {
+      psbt_1.Psbt.fromBuffer(Buffer.from(f.hex, 'hex'), fromBuf, {
+        bip32PathsAbsolute: false,
+      });
+    }, new RegExp(f.exception));
     t.end();
   });
 }

--- a/ts_src/lib/converter/shared/tapBip32Derivation.ts
+++ b/ts_src/lib/converter/shared/tapBip32Derivation.ts
@@ -7,7 +7,7 @@ const isValidBIP340Key = (pubkey: Buffer): boolean => pubkey.length === 32;
 export function makeConverter(
   TYPE_BYTE: number,
 ): {
-  decode: (keyVal: KeyValue) => TapBip32Derivation;
+  decode: (keyVal: KeyValue, bip32PathsAbsolute: boolean) => TapBip32Derivation;
   encode: (data: TapBip32Derivation) => KeyValue;
   check: (data: any) => data is TapBip32Derivation;
   expected: string;
@@ -18,13 +18,19 @@ export function makeConverter(
   ) => boolean;
 } {
   const parent = bip32Derivation.makeConverter(TYPE_BYTE, isValidBIP340Key);
-  function decode(keyVal: KeyValue): TapBip32Derivation {
+  function decode(
+    keyVal: KeyValue,
+    bip32PathsAbsolute = true,
+  ): TapBip32Derivation {
     const nHashes = varuint.decode(keyVal.value);
     const nHashesLen = varuint.encodingLength(nHashes);
-    const base = parent.decode({
-      key: keyVal.key,
-      value: keyVal.value.slice(nHashesLen + nHashes * 32),
-    });
+    const base = parent.decode(
+      {
+        key: keyVal.key,
+        value: keyVal.value.slice(nHashesLen + nHashes * 32),
+      },
+      bip32PathsAbsolute,
+    );
     const leafHashes: Buffer[] = new Array(nHashes);
     for (let i = 0, _offset = nHashesLen; i < nHashes; i++, _offset += 32) {
       leafHashes[i] = keyVal.value.slice(_offset, _offset + 32);

--- a/ts_src/lib/parser/fromBuffer.ts
+++ b/ts_src/lib/parser/fromBuffer.ts
@@ -15,6 +15,7 @@ import { PsbtAttributes } from './index';
 export function psbtFromBuffer(
   buffer: Buffer,
   txGetter: TransactionFromBuffer,
+  { bip32PathsAbsolute = true } = {},
 ): PsbtAttributes {
   let offset = 0;
 
@@ -139,11 +140,15 @@ export function psbtFromBuffer(
     outputKeyVals.push(output);
   }
 
-  return psbtFromKeyVals(unsignedTx, {
-    globalMapKeyVals,
-    inputKeyVals,
-    outputKeyVals,
-  });
+  return psbtFromKeyVals(
+    unsignedTx,
+    {
+      globalMapKeyVals,
+      inputKeyVals,
+      outputKeyVals,
+    },
+    { bip32PathsAbsolute },
+  );
 }
 
 interface PsbtFromKeyValsArg {
@@ -167,6 +172,7 @@ export function checkKeyBuffer(
 export function psbtFromKeyVals(
   unsignedTx: Transaction,
   { globalMapKeyVals, inputKeyVals, outputKeyVals }: PsbtFromKeyValsArg,
+  { bip32PathsAbsolute = true } = {},
 ): PsbtAttributes {
   // That was easy :-)
   const globalMap: PsbtGlobal = {
@@ -259,7 +265,7 @@ export function psbtFromKeyVals(
             input.bip32Derivation = [];
           }
           input.bip32Derivation.push(
-            convert.inputs.bip32Derivation.decode(keyVal),
+            convert.inputs.bip32Derivation.decode(keyVal, bip32PathsAbsolute),
           );
           break;
         case InputTypes.FINAL_SCRIPTSIG:
@@ -297,7 +303,10 @@ export function psbtFromKeyVals(
             input.tapBip32Derivation = [];
           }
           input.tapBip32Derivation.push(
-            convert.inputs.tapBip32Derivation.decode(keyVal),
+            convert.inputs.tapBip32Derivation.decode(
+              keyVal,
+              bip32PathsAbsolute,
+            ),
           );
           break;
         case InputTypes.TAP_INTERNAL_KEY:
@@ -342,7 +351,7 @@ export function psbtFromKeyVals(
             output.bip32Derivation = [];
           }
           output.bip32Derivation.push(
-            convert.outputs.bip32Derivation.decode(keyVal),
+            convert.outputs.bip32Derivation.decode(keyVal, bip32PathsAbsolute),
           );
           break;
         case OutputTypes.TAP_INTERNAL_KEY:
@@ -358,7 +367,10 @@ export function psbtFromKeyVals(
             output.tapBip32Derivation = [];
           }
           output.tapBip32Derivation.push(
-            convert.outputs.tapBip32Derivation.decode(keyVal),
+            convert.outputs.tapBip32Derivation.decode(
+              keyVal,
+              bip32PathsAbsolute,
+            ),
           );
           break;
         default:

--- a/ts_src/lib/psbt.ts
+++ b/ts_src/lib/psbt.ts
@@ -32,24 +32,29 @@ export class Psbt {
     this: T,
     data: string,
     txFromBuffer: TransactionFromBuffer,
+    { bip32PathsAbsolute = true } = {},
   ): InstanceType<T> {
     const buffer = Buffer.from(data, 'base64');
-    return this.fromBuffer(buffer, txFromBuffer);
+    return this.fromBuffer(buffer, txFromBuffer, { bip32PathsAbsolute });
   }
   static fromHex<T extends typeof Psbt>(
     this: T,
     data: string,
     txFromBuffer: TransactionFromBuffer,
+    { bip32PathsAbsolute = true } = {},
   ): InstanceType<T> {
     const buffer = Buffer.from(data, 'hex');
-    return this.fromBuffer(buffer, txFromBuffer);
+    return this.fromBuffer(buffer, txFromBuffer, { bip32PathsAbsolute });
   }
   static fromBuffer<T extends typeof Psbt>(
     this: T,
     buffer: Buffer,
     txFromBuffer: TransactionFromBuffer,
+    { bip32PathsAbsolute = true } = {},
   ): InstanceType<T> {
-    const results = psbtFromBuffer(buffer, txFromBuffer);
+    const results = psbtFromBuffer(buffer, txFromBuffer, {
+      bip32PathsAbsolute,
+    });
     const psbt = new this(results.globalMap.unsignedTx) as InstanceType<T>;
     Object.assign(psbt, results);
     return psbt;

--- a/ts_src/tests/fixtures/update.ts
+++ b/ts_src/tests/fixtures/update.ts
@@ -63,7 +63,7 @@ export const fixtures = [
             pubkey: b(
               '023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e73',
             ),
-            path: "m/0'/0'/3'",
+            path: "0'/0'/3'",
           },
           {
             masterFingerprint: b('d90c6a4f'),
@@ -94,7 +94,7 @@ export const fixtures = [
             pubkey: b(
               '027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b50051096',
             ),
-            path: "m/0'/0'/5'",
+            path: "0'/0'/5'",
           },
         ],
       },

--- a/ts_src/tests/fromBIP/valid.ts
+++ b/ts_src/tests/fromBIP/valid.ts
@@ -3,18 +3,48 @@ import { Psbt } from '../../lib/psbt';
 import { fixtures } from '../fixtures/valid';
 import { transactionFromBuffer } from '../utils/txTools';
 
-for (const f of fixtures) {
-  tape(`Test: Should not throw`, t => {
-    let psbt: Psbt;
-    t.doesNotThrow(() => {
-      psbt = Psbt.fromBase64(f, transactionFromBuffer);
-    }, 'fromBase64');
-
-    t.doesNotThrow(() => {
-      const out = psbt.toBase64();
-      t.equal(out, f);
-    }, 'toBase64');
-
-    t.end();
-  });
+interface ContainsBip32Paths {
+  bip32Derivation?: Array<{ path: string }>;
+  tapBip32Derivation?: Array<{ path: string }>;
 }
+
+function getPaths(m: ContainsBip32Paths[]): string[] {
+  return m
+    .map(ele =>
+      [...(ele.bip32Derivation || []), ...(ele.tapBip32Derivation || [])].map(
+        ({ path }) => path,
+      ),
+    )
+    .reduce((a, b) => [...a, ...b], []);
+}
+
+[true, false].forEach(bip32PathsAbsolute => {
+  for (const f of fixtures) {
+    tape(
+      `Test: Should not throw (bip32PathsAbsolute:${bip32PathsAbsolute})`,
+      t => {
+        let psbt: Psbt;
+        t.doesNotThrow(() => {
+          psbt = Psbt.fromBase64(f, transactionFromBuffer, {
+            bip32PathsAbsolute,
+          });
+          const paths = [...getPaths(psbt.inputs), ...getPaths(psbt.outputs)];
+          paths.forEach(path => {
+            if (bip32PathsAbsolute) {
+              t.equal(path[0], 'm');
+            } else if (path.length > 0) {
+              t.assert(path[0].match(/\d/));
+            }
+          });
+        }, 'fromBase64');
+
+        t.doesNotThrow(() => {
+          const out = psbt.toBase64();
+          t.equal(out, f);
+        }, 'toBase64');
+
+        t.end();
+      },
+    );
+  }
+});

--- a/ts_src/tests/fromBuffer.ts
+++ b/ts_src/tests/fromBuffer.ts
@@ -33,6 +33,17 @@ for (const f of fixtures) {
     t.throws(() => {
       Psbt.fromHex(f.hex, fromBuf);
     }, new RegExp(f.exception));
+    t.throws(() => {
+      Psbt.fromBuffer(Buffer.from(f.hex, 'hex'), fromBuf);
+    }, new RegExp(f.exception));
+    t.throws(() => {
+      Psbt.fromHex(f.hex, fromBuf, { bip32PathsAbsolute: false });
+    }, new RegExp(f.exception));
+    t.throws(() => {
+      Psbt.fromBuffer(Buffer.from(f.hex, 'hex'), fromBuf, {
+        bip32PathsAbsolute: false,
+      });
+    }, new RegExp(f.exception));
     t.end();
   });
 }


### PR DESCRIPTION
Allow relative BIP32Derivation paths to be relative with an optional flag during deserialization. Additionally, during serialization, correct the serialization of relative derivation paths.

[BG-54756](https://bitgoinc.atlassian.net/browse/BG-54756)

[BG-54756]: https://bitgoinc.atlassian.net/browse/BG-54756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ