### PR TITLE
chore: add required release branch to semantic-release config

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - '!release-do-not-use'
   pull_request:
 
 jobs:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": [
+    "release-do-not-use",
     {
       "name": "master",
       "prerelease": true


### PR DESCRIPTION
Following this documentation[^1], configure a release branch (a non-
pre-release branch) in semantic-release to avoid an `ERELEASEBRANCHES`
error.

[^1]: https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches