### PR TITLE
docs: update maintainers note

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 BitGo's fork of a [BIP174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki) compatible partial Transaction encoding library.
 
 *When rebasing this fork on upstream, tag the upstream commit with a base
-version that semver should continue from. Eg. upstream `v2.1.0` might get
-tagged with `v3.1.0-rc.0`, so that semver picks up from `v3.1.0-rc.1`.*
+version that semantic-release should continue from. Eg. upstream `v2.1.0` might get
+tagged with `v3.1.0`, so that semantic-release picks up from `v3.1.0-rc.1`.*
 
 ## Bitcoin users, use bitcoinjs-lib's Psbt class.
 


### PR DESCRIPTION
Apparently semantic-release doesn't explicitly look for rc-based tags;
it looks backwards only for full-release channel tags.

Therefore, update the maintainer's note with instructions to bootstrap a
full-release tag, so that moving forwards, semantic-release will create
release-candidate tags from that starting position.