### PR TITLE
ci: modify workflow .yaml to work with Trusted Publisher

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -91,5 +91,5 @@ jobs:
       - run: npm ci
       - run: ./node_modules/.bin/semantic-release
         env:
-          NPM_TOKEN: "n/a"
+          NPM_TOKEN: "FAKE_NPM_TOKEN_FOR_SEMANTIC_RELEASE"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -78,14 +78,18 @@ jobs:
       - format
       - gitdiff
       - lint
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
           cache: 'npm'
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: ./node_modules/.bin/semantic-release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: "n/a"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Summary:**
This PR updates the GitHub Actions release workflow to use npm Trusted Publishing (OIDC) instead of long-lived `NPM_TOKEN` secrets.

**Changes:**
- Added `permissions: id-token: write` for OIDC-based publishing
- I added a dummy value `"FAKE_NPM_TOKEN_FOR_SEMANTIC_RELEASE"` in all repos to ensure that semantic-release passes

**Why:**
- We want to eliminate long-lived npm tokens, and use GitHub’s OIDC-based authentication for npm publishing instead
- Our semantic-release workflow (`semantic-release-action/typescript/blob/master/.github/workflows/release.yml`) defines `npm-token` as a required secret. So if it’s missing, the release can sometimes fail early or behave inconsistently. Some repos throw a hard error (`“Secret npm-token is required”`), while others partially run and then stop. By setting the dummy token, we eliminate those inconsistencies, guarantee that all release workflows start cleanly across repos, and ensure that future developers don't get confused as to why there is no `npm-token`
It doesn’t actually authenticate to npm, so it’s a harmless placeholder that prevents future CI failures

**Expected outcome:**
- Future releases will publish securely through GitHub’s OIDC workflow
- `npm-token` secrets are no longer required
- npm packages will show a "GitHub Actions" verification at the top of the npm package indicating that the Trusted Publishing has worked

Ticket: DX-2081